### PR TITLE
Use lowercase root name and password vars

### DIFF
--- a/templates/backup-pre-mongodb.sh
+++ b/templates/backup-pre-mongodb.sh
@@ -4,4 +4,4 @@ TMPDIR='{{ MONGODB_SERVER_BACKUP_DIR }}'
 
 rm -rf "$TMPDIR"
 sudo -u mongodb mkdir -p "$TMPDIR"
-sudo -u mongodb mongodump -u '{{ MONGODB_ROOT_ADMIN_NAME }}' -p '{{ MONGODB_ROOT_ADMIN_PASSWORD }}' -o "$TMPDIR"
+sudo -u mongodb mongodump -u '{{ mongodb_root_admin_name }}' -p '{{ mongodb_root_admin_password }}' -o "$TMPDIR"


### PR DESCRIPTION
This role uses uppercase `MONGODB_ROOT_ADMIN_*` variables, but our playbooks and the [greendayonfile.mongodb role](https://github.com/UnderGreen/ansible-role-mongodb) use lowercase `mongodb_root_admin_*` variables. This causes the following error:

```
TASK [mongodb : Copy pre-backup script] ****************************************
fatal: [mongodb-stage.opencraft.hosting]: FAILED! => {"changed": false, "failed": true, "msg": "AnsibleUndefinedVariable: 'MONGODB_ROOT_ADMIN_NAME' is undefined"}
```

This pull request modifies this role to use the same lowercase variable names as our playbooks.
