### PR TITLE
Make mongodb backup one database at a time

### DIFF
--- a/templates/backup-pre-mongodb.sh
+++ b/templates/backup-pre-mongodb.sh
@@ -4,4 +4,10 @@ TMPDIR='{{ MONGODB_SERVER_BACKUP_DIR }}'
 
 rm -rf "$TMPDIR"
 sudo -u mongodb mkdir -p "$TMPDIR"
-sudo -u mongodb mongodump -u '{{ mongodb_root_admin_name }}' -p '{{ mongodb_root_admin_password }}' -o "$TMPDIR"
+DBNAMES=`echo "show databases;" | \
+         sudo -u mongodb mongo --quiet -u '{{ mongodb_root_admin_name }}' -p '{{ mongodb_root_admin_password }}' 127.0.0.1:{{ mongodb_net_port }}/admin | \
+         awk '{ print $1; }'`
+
+for DBNAME in $DBNAMES; do
+    sudo -u mongodb mongodump -u '{{ mongodb_root_admin_name }}' -p '{{ mongodb_root_admin_password }}' --authenticationDatabase admin --db "$DBNAME" --out "$TMPDIR"
+done


### PR DESCRIPTION
This pull request makes MongoDB backup databases one at a time instead of all at once and inserts a small delay between backups.